### PR TITLE
Add dimension to path data

### DIFF
--- a/d3.parsets.js
+++ b/d3.parsets.js
@@ -614,6 +614,7 @@
               children: j === nd - 1 ? null : {},
               count: 0,
               parent: node,
+              dimension: dimension,
               name: category
             };
       }


### PR DESCRIPTION
Having the dimension in the data can allow for filtering the data or improved event handling options.
