### PR TITLE
tooltip and css

### DIFF
--- a/d3.parsets.css
+++ b/d3.parsets.css
@@ -26,3 +26,9 @@ path.active { fill-opacity: .9; }
 .category-7 { fill: #7f7f7f; stroke: #7f7f7f; }
 .category-8 { fill: #bcbd22; stroke: #bcbd22; }
 .category-9 { fill: #17becf; stroke: #17becf; }
+
+.tooltip {
+    background-color: rgba(242, 242, 242, .6);
+    position: absolute;
+    padding: 5px;
+}

--- a/d3.parsets.js
+++ b/d3.parsets.js
@@ -409,10 +409,7 @@
     var body = d3.select("body");
     var tooltip = body.append("div")
         .style("display", "none")
-        .style("background-color", "#eee")
-        .style("background-color", "rgba(242, 242, 242, .6)")
-        .style("padding", "5px")
-        .style("position", "absolute");
+        .attr("class", "parsets tooltip");
 
     return d3.rebind(parsets, event, "on").value(1).width(960).height(600);
 


### PR DESCRIPTION
The following tiny changeset makes it so that the tooltip style is deferred to css by adding a tooltip class.
