### PR TITLE
Fix bug with tooltip overrides

### DIFF
--- a/d3.parsets.js
+++ b/d3.parsets.js
@@ -410,7 +410,7 @@
 
     parsets.tooltip = function(_) {
       if (!arguments.length) return tooltip;
-      tooltip = _ == null ? defaultTooltip : _;
+      tooltip_ = _ == null ? defaultTooltip : _;
       return parsets;
     };
 


### PR DESCRIPTION
When overriding the tooltip, the provided function was getting assigned into `tooltip` - the DOM element for the tooltip rather than `tooltip_` - the var that holds the tooltip function.
