### PR TITLE
increase contrast when hovering ribbons

### DIFF
--- a/d3.parsets.css
+++ b/d3.parsets.css
@@ -13,6 +13,7 @@
 .dimension:hover > rect { fill-opacity: .3; }
 .ribbon path { stroke-opacity: 0; fill-opacity: .5; }
 .ribbon path.active { fill-opacity: .9; }
+.ribbon path.inactive { fill-opacity: .2; }
 .ribbon-mouse path { fill-opacity: 0; }
 
 .category-0 { fill: #1f77b4; stroke: #1f77b4; }

--- a/d3.parsets.js
+++ b/d3.parsets.js
@@ -263,17 +263,19 @@
           })(d);
           highlight.shift();
           if (ancestors) while (d) highlight.push(d), d = d.parent;
+          ribbon.classed("inactive", true);
           ribbon.filter(function(d) {
             var active = highlight.indexOf(d.node) >= 0;
             if (active) this.parentNode.appendChild(this);
             return active;
-          }).classed("active", true);
+          }).classed("active", true).classed("inactive", false);;
         }
 
         // Unhighlight all nodes.
         function unhighlight() {
           if (dragging) return;
           ribbon.classed("active", false);
+          ribbon.classed("inactive", false);
           hideTooltip();
         }
 


### PR DESCRIPTION
Increase the contrast when hovering ribbons by decreasing the opacity of inactive ribbons.

![parsets-contrast](https://cloud.githubusercontent.com/assets/503112/7105234/7c629726-e141-11e4-8dac-88a86c61c1e1.png)
